### PR TITLE
Fix for permanent authentication failure if initial call to loadAuthenticationKey fails

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -418,7 +418,7 @@ class Reader extends EventEmitter {
 			}
 
 			try {
-				await this.pendingLoadAuthenticationKey[key];
+				keyNumber = await this.pendingLoadAuthenticationKey[key];
 			} catch (err) {
 				throw new AuthenticationError('unable_to_load_key', 'Could not load authentication key into reader.', err);
 			}


### PR DESCRIPTION
When using authentication, it seems like a condition can occur that is impossible to recover from. It can be reproduced as follows:

1. Comment out the procedure to read with authentication in `examples/index.js` (lines 70-86, except for line 78)
2. Run the example script with an ACR122u reader: `npm run example`
3. Quickly tap a card (for example, Mifare 1K), pulling away before it has a chance to fully authenticate (< ~300ms)
4. Every subsequent read should now fail with `error when authenticating data`

When inspecting the code, this seems originate from [Line 423 in Reader.js](https://github.com/pokusew/nfc-pcsc/blob/master/src/Reader.js#L423) where the Promise of `load AuthenticationKey` is being stored in `this.pendingLoadAuthenticationKey` - presumably to be able to wait for this Promise to resolve at a later time. 

However, if this Promise is rejected (for example, a failed auth operation in `loadAuthenticationKey`), the rejected promise will now be stored in `this.pendingLoadAuthenticationKey`. Later calls to `authenticate` will now [continue to `await` on this rejected Promise and never complete](https://github.com/pokusew/nfc-pcsc/blob/master/src/Reader.js#L402).

This pull request removes the tracking of Promises in `this.pendingLoadAuthenticationKey` so subsequent calls to `authenticate` will now run the whole authentication key load procedure if the key is not present, no matter the result of the initial call. I believe `await` should ensure it will always run to completion anyway (except in case of an exception, of course).

I want to make sure I'm not regressing any existing use-cases, so let me know if I'm missing your original intent when using `pendingLoadAuthenticationKey` or overlooking any situations dictating its need.
