### PR TITLE
Add CONNECT_MODE_EXCLUSIVE

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -26,6 +26,7 @@ export const KEY_TYPE_B = 0x61;
 
 export const CONNECT_MODE_DIRECT = 'CONNECT_MODE_DIRECT';
 export const CONNECT_MODE_CARD = 'CONNECT_MODE_CARD';
+export const CONNECT_MODE_EXCLUSIVE = 'CONNECT_MODE_EXCLUSIVE';
 
 
 class Reader extends EventEmitter {
@@ -217,6 +218,7 @@ class Reader extends EventEmitter {
 		const modes = {
 			[CONNECT_MODE_DIRECT]: this.reader.SCARD_SHARE_DIRECT,
 			[CONNECT_MODE_CARD]: this.reader.SCARD_SHARE_SHARED,
+			[CONNECT_MODE_EXCLUSIVE]: this.reader.SCARD_SHARE_EXCLUSIVE,
 		};
 
 		if (!modes[mode]) {


### PR DESCRIPTION
In some use cases, it is required to open the card in "exclusive" mode, especially if some stateful operations are involved. If the card is not opened in the exclusive mode, multiple services may try to talk to it at once (for instance: Windows system itself). In some use cases, this disrupts proper operation.

Without the possibility to open the reader in exclusive mode, this library doesn't reliably work with:
https://www.npmjs.com/package/node-gp